### PR TITLE
Add --no-tty switch to gpg to avoid /dev/tty not found error and brea…

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -77,11 +77,11 @@ RUN set -ex; \
 			keyserver.ubuntu.com \
 			hkp://keyserver.ubuntu.com:80 \
 			pgp.mit.edu; do \
-			gpg --keyserver $server --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break 2; \
+			gpg --keyserver $server --no-tty --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break 2; \
 		done; \
 		sleep 10; \
 	done; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpg --batch --verify --no-tty /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
 	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	\
 	chmod +x /usr/local/bin/gosu; \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -77,11 +77,11 @@ RUN set -ex; \
 			keyserver.ubuntu.com \
 			hkp://keyserver.ubuntu.com:80 \
 			pgp.mit.edu; do \
-			gpg --keyserver $server --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break 2; \
+			gpg --keyserver $server --no-tty --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break 2; \
 		done; \
 		sleep 10; \
 	done; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpg --batch --verify --no-tty /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
 	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	\
 	chmod +x /usr/local/bin/gosu; \

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -63,7 +63,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
 		sed -i "s/MYSQL_PASSWORD/${MYSQL_PASSWORD}/" "$profile"
 
-		unzip -d /var/www/html /usr/src/deskpro.zip
+		unzip -f -d /var/www/html /usr/src/deskpro.zip
 		chown -R www-data:www-data /var/www/html/
 
 		cd /var/www/html/ && bin/install --profile "$profile" --no-interaction

--- a/docker-compose-test-fpm.yml
+++ b/docker-compose-test-fpm.yml
@@ -30,7 +30,7 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro,z
       - deskpro-fpm:/var/www/html:ro
   mariadb:
-    image: mariadb
+    image: mariadb:10.3
     environment:
       MYSQL_ROOT_PASSWORD: mysqlrootpassword
       MYSQL_DATABASE: deskprodb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,1 @@
+docker-compose-test-fpm.yml

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -76,11 +76,11 @@ RUN set -ex; \
 			keyserver.ubuntu.com \
 			hkp://keyserver.ubuntu.com:80 \
 			pgp.mit.edu; do \
-			gpg --keyserver $server --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break 2; \
+			gpg --keyserver $server --no-tty --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break 2; \
 		done; \
 		sleep 10; \
 	done; \
-	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpg --batch --verify --no-tty /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
 	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
 	\
 	chmod +x /usr/local/bin/gosu; \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -34,6 +34,8 @@ RUN set -x \
 	&& docker-php-ext-install -j$(nproc) imap \
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
 	&& docker-php-ext-install -j$(nproc) ldap \
+        && docker-php-ext-configure opcache --enable-opcache \
+	&& docker-php-ext-install opcache \ 
 	&& apt-get remove -y \
 		libc-client-dev \
 		libfreetype6-dev \

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -63,7 +63,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
 		sed -i "s/MYSQL_PASSWORD/${MYSQL_PASSWORD}/" "$profile"
 
-		unzip -d /var/www/html /usr/src/deskpro.zip
+		unzip -f -d /var/www/html /usr/src/deskpro.zip
 		chown -R www-data:www-data /var/www/html/
 
 		cd /var/www/html/ && bin/install --profile "$profile" --no-interaction

--- a/fpm/php.ini
+++ b/fpm/php.ini
@@ -1,5 +1,15 @@
 [PHP]
 short_open_tag = off
-
+upload_max_filesize = 512M
+max_execution_time = 60
+max_input_time = 300
+max_input_vars = 2000
+memory_limit = 512M
 [Date]
-date.timezone = UTC
+date.timezone = Tehran/Iran
+[opcache]
+opcache.enable=1
+opcache.memory_consumption=512
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=10000
+

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,7 +2,7 @@
 # https://support.deskpro.com/en/kb/articles/using-deskpro-with-nginx
 
 user  nginx;
-worker_processes  1;
+worker_processes  auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
@@ -27,7 +27,7 @@ http {
 
   gzip on;
 
-  resolver 127.0.0.11;
+  resolver 8.8.8.8;
 
   server {
     server_name _;


### PR DESCRIPTION
Add --no-tty switch to gpg.
It will avoid no /dev/tty error when adding gpg key into docker container.
